### PR TITLE
Norc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+1.4.3
+-Fixed issue the player's hand invisibly blocked more space than required by their cards.
+-Fixed issue where the player hand could still overlap the sidebar if the player's hand was moved to the right using settings. 
+-Minor cosmetic improvements to the vertical player hand control bar and user settings.
+
+1.4.2
+-Minor bugfix for issue where draw with replacement was always on when drawing using the vertical controls next to the player's hand.
+
 1.4.1
 - Added confirm dialog to Burn in Context Menu
 - Bugfixes for Deck Interaction Form not working for GM

--- a/dist/cardhotbar/card-hotbar.js
+++ b/dist/cardhotbar/card-hotbar.js
@@ -119,8 +119,9 @@ export class cardHotbar extends Hotbar {
       }
     }
     let root = document.documentElement;
+    //console.debug(`Card Hotbar | Is the card hotbar collapsed: ${this._collapsed}`);
     root.style.setProperty("--rawwidth", ( ui.cardHotbar.totScaledWidth + "px") );
-    console.debug(`Card Hotbar | Total image widths is: ${this.totScaledWidth}`);
+    //console.debug(`Card Hotbar | Total image widths is: ${this.totScaledWidth}`);
     return macros;
   }
 
@@ -224,6 +225,8 @@ export class cardHotbar extends Hotbar {
         bar.addClass("collapsed");
         ui.cardHotbar.element.addClass("collapsed");
         this._collapsed = true;
+        let root = document.documentElement;
+        root.style.setProperty("--rawwidth", "0px" );
         resolve(true);
       });
     });

--- a/dist/cardhotbar/card-hotbar.js
+++ b/dist/cardhotbar/card-hotbar.js
@@ -1,5 +1,6 @@
 //import { Deck } from "../scripts/deck.js";
 import {DeckForm} from '../scripts/DeckForm.js';
+//import { updateIdentifier } from 'typescript';
 
 export class cardHotbar extends Hotbar {
     /**
@@ -39,6 +40,12 @@ export class cardHotbar extends Hotbar {
     /**
      * 
      */
+    this.totScaledWidth = 0;
+
+
+    /**
+     * 
+     */    
     this.populator = populator;
   }
   
@@ -75,6 +82,7 @@ export class cardHotbar extends Hotbar {
   _getcardMacrosByPage(page) { 
     let lastCard = false;
     const macros = this.getcardHotbarMacros(page);
+    this.totScaledWidth = 0;
     for ( let [i, m] of macros.entries() ) {
       m.key = i<53 ? i+1 : 0;
       m.cssClass = m.macro ? "active" : "inactive";    
@@ -83,9 +91,10 @@ export class cardHotbar extends Hotbar {
       //TO DO: improve to replace hard-coded value with the default draw-mode?
       //getComputedStyle(document.documentElement).getPropertyValue('--width');
       //element.style.setProperty("--my-var", jsVar + 4);
-      let defaultWidth = 138;
+      let defaultWidth = m.icon ? 138 : 0;
       let sw = m.macro ? m.macro.getFlag("world","scaledWidth") || defaultWidth : defaultWidth;
       m.scaledWidth = sw ? sw : defaultWidth;
+      this.totScaledWidth += m.scaledWidth; 
       let defaultSide = "front";
       let curSide = m.macro ? m.macro.getFlag("world","sideUp") || defaultSide : defaultSide;
       m.sideUp = curSide ? curSide : defaultSide;
@@ -109,6 +118,9 @@ export class cardHotbar extends Hotbar {
         lastCard = true;
       }
     }
+    let root = document.documentElement;
+    root.style.setProperty("--rawwidth", ( ui.cardHotbar.totScaledWidth + "px") );
+    console.debug(`Card Hotbar | Total image widths is: ${this.totScaledWidth}`);
     return macros;
   }
 

--- a/dist/cardhotbar/css/card-hotbar.css
+++ b/dist/cardhotbar/css/card-hotbar.css
@@ -3,7 +3,9 @@
 :root {
     --width: 138px;
     --xoffset: 0px;
-    --totwidth: calc(100vw - 600px - var(--xoffset) );
+    --rawwidth: 100vw; 
+    --totwidth: min( var(--rawwidth), calc(100vw - 600px - var(--xoffset) ) );
+    /* --totwidth: calc( 100vw - 600px - var(--xoffset) ); */
 }
 
 /* TO DO: figure out why so wide, even after hiding cards */

--- a/dist/cardhotbar/css/card-hotbar.css
+++ b/dist/cardhotbar/css/card-hotbar.css
@@ -20,6 +20,7 @@
 
 #card-hotbar.collapsed {
     height: 50px;
+    width: var(--totwidth);
 }
 
 #card-hotbar #card-hotbar-directory-controls {

--- a/dist/cardhotbar/css/card-hotbar.css
+++ b/dist/cardhotbar/css/card-hotbar.css
@@ -330,6 +330,15 @@ div#client-settings div#chbSetDiv {
   order: -1;
 }
 
+#client-settings form .form-group.submenu.chb-setting button label {
+    display: inline-block;
+    padding-top: 0px;
+    margin-top: -8px;
+    margin-left: 5px;
+    line-height: 22px;
+    vertical-align: middle;
+}
+
 .macro .tooltip span {
     z-index: 4;
 }

--- a/dist/cardhotbar/css/card-hotbar.css
+++ b/dist/cardhotbar/css/card-hotbar.css
@@ -2,6 +2,8 @@
 
 :root {
     --width: 138px;
+    --xoffset: 0px;
+    --totwidth: calc(100vw - 600px - var(--xoffset) );
 }
 
 /* TO DO: figure out why so wide, even after hiding cards */
@@ -84,7 +86,7 @@
 #card-hotbar #card-action-bar {
     pointer-events: all;
     height: 100%;
-    width: calc(100vw - 600px);
+    width: var(--totwidth);
 }
 
 #card-hotbar .bar-controls {
@@ -122,13 +124,11 @@
     justify-content: center;
     align-items: center;
     position: relative;
-    /* border: 1px dashed #999999; */
     border-radius: 10px;
     background: #99999980;
     cursor: pointer;
     margin-top: auto;
     margin-bottom: auto;
-    /*width: var(--width);*/
     height: 100%;
     top: 0px;
     box-shadow: 0px 0 4px black;

--- a/dist/cardhotbar/css/card-hotbar.css
+++ b/dist/cardhotbar/css/card-hotbar.css
@@ -32,6 +32,7 @@
 }
 
 #card-hotbar #card-hotbar-directory-controls.collapsed img.collapsed {
+    border: none;
     display: block;
 }
 
@@ -64,10 +65,21 @@
     margin-bottom: auto;
 }
 
+#card-hotbar #card-hotbar-directory-controls div.vertbar a img {
+    border: none;
+}
+
+
 #card-hotbar #card-hotbar-directory-controls div.expanded a {
     margin-top: auto;
     margin-bottom: auto;
 }
+
+#card-hotbar #card-hotbar-directory-controls div.expanded a {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
 
 #card-hotbar #card-action-bar {
     pointer-events: all;

--- a/dist/cardhotbar/index.js
+++ b/dist/cardhotbar/index.js
@@ -66,11 +66,11 @@ async function cardHotbarInit() {
   , style = document.createElement('style');
 
   head.appendChild(style);
+  style.type = 'text/css';
+  style.appendChild(document.createTextNode(css));
 
   let root = document.documentElement;
   root.style.setProperty("--xoffset", ( cardHotbarSettings.getCHBXPos() - 220 )+ "px");
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(css));
 
 //  ui.hotbar.render();
 
@@ -117,7 +117,7 @@ Hooks.once("init", async () => {
   };
 });
 
-Hooks.once('ready', () => {
+Hooks.once('ready', async () => {
   //console.debug("Card Hotbar | Foundry setup...");
 
   //Check to make sure that a hotbar rendered before initilizing so that PopOut module windows do not have unwanted card hotbars.
@@ -126,9 +126,9 @@ Hooks.once('ready', () => {
   //console.debug(hotbarTest);
  
   if ( hotbarTest ) {
-    cardHotbarInit();
+    await cardHotbarInit();
   }
-
+  
 });
 
 Hooks.on("renderSettingsConfig", async () => {

--- a/dist/cardhotbar/index.js
+++ b/dist/cardhotbar/index.js
@@ -67,6 +67,8 @@ async function cardHotbarInit() {
 
   head.appendChild(style);
 
+  let root = document.documentElement;
+  root.style.setProperty("--xoffset", ( cardHotbarSettings.getCHBXPos() - 220 )+ "px");
   style.type = 'text/css';
   style.appendChild(document.createTextNode(css));
 

--- a/dist/cardhotbar/scripts/card-hotbar-populator.js
+++ b/dist/cardhotbar/scripts/card-hotbar-populator.js
@@ -2,8 +2,7 @@
 
 export class cardHotbarPopulator {
     constructor() { 
-        this.macroMap = this.chbGetMacros();
-        getComputedStyle(document.documentElement).getPropertyValue('--width');    
+        this.macroMap = this.chbGetMacros();    
         console.debug("Card Hotbar | Initial state:");
         console.debug(this.macroMap);
     }

--- a/dist/cardhotbar/scripts/card-hotbar-settings.js
+++ b/dist/cardhotbar/scripts/card-hotbar-settings.js
@@ -11,7 +11,7 @@ export class cardHotbarSettings {
         game.settings.registerMenu("cardsupport", 'chbSettingsMenu', {
             name: '(𝗚𝗠 𝗢𝗻𝗹𝘆) Default Player Hand Settings for All Users',
             label: 'Global Player Hand',
-            icon: 'fas fa-bars',
+            icon: 'icon-pokerhand fa-2x',
             type: cardHotbarSettingsForm,
             restricted: true
         });
@@ -20,7 +20,7 @@ export class cardHotbarSettings {
         game.settings.registerMenu("cardsupport", 'chbFlagsMenu', {
             name: 'Your Hand of Cards Settings',
             label: 'Your Hand of Cards',
-            icon: 'fas fa-bars',
+            icon: 'icon-pokerhand fa-2x',
             type: cardHotbarFlagsForm,
             restricted: false
         });

--- a/dist/cardhotbar/templates/cardHotbar.html
+++ b/dist/cardhotbar/templates/cardHotbar.html
@@ -6,7 +6,7 @@
             <img src="modules/cardsupport/cardhotbar/img/poker-hand.png" class="collapsed">
         </a>
         <div class= "expanded vertbar" >        
-            <a id="chbDiscardAll" title="Discard All"><i class="fas fa-trash" ></i></a>
+            <a id="chbDiscardAll" title="Discard All"><i class="fas fa-inbox" ></i></a>
             <a id="chbTakeFromPlayer" title="Take From Player"><i class="icon-hand" ></i></a>
             <a id="chbInteractDecks" title="Interact with Decks"><i class="icon-deck-of-cards"></i></a>
         </div>

--- a/dist/cardhotbar/templates/cardHotbar.html
+++ b/dist/cardhotbar/templates/cardHotbar.html
@@ -2,8 +2,8 @@
     <div id="card-hotbar-directory-controls" class="bar-controls flexcol">
         <a id="card-bar-toggle">
             <i class="fas fa-times"></i>
-            <i class="fas fa-caret-down"></i>
-            <i class="collapsed icon-pokerhand"></i>
+            <i class="fas fa-caret-up"></i>
+            <img src="modules/cardsupport/cardhotbar/img/poker-hand.png" class="collapsed">
         </a>
         <div class= "expanded vertbar" >        
             <a id="chbDiscardAll" title="Discard All"><i class="fas fa-trash" ></i></a>

--- a/dist/module.json
+++ b/dist/module.json
@@ -3,7 +3,7 @@
   "title": "Card Support (Unofficial)",
   "description": "Unofficial deck support for foundry that allows you to have cards and player hands and the like.",
   "author": "Spacemandev, Norc",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.7.0",
   "url": "https://github.com/Brownie79/fvtt-card-support",

--- a/src/cardhotbar/card-hotbar.js
+++ b/src/cardhotbar/card-hotbar.js
@@ -119,8 +119,9 @@ export class cardHotbar extends Hotbar {
       }
     }
     let root = document.documentElement;
+    //console.debug(`Card Hotbar | Is the card hotbar collapsed: ${this._collapsed}`);
     root.style.setProperty("--rawwidth", ( ui.cardHotbar.totScaledWidth + "px") );
-    console.debug(`Card Hotbar | Total image widths is: ${this.totScaledWidth}`);
+    //console.debug(`Card Hotbar | Total image widths is: ${this.totScaledWidth}`);
     return macros;
   }
 
@@ -224,6 +225,8 @@ export class cardHotbar extends Hotbar {
         bar.addClass("collapsed");
         ui.cardHotbar.element.addClass("collapsed");
         this._collapsed = true;
+        let root = document.documentElement;
+        root.style.setProperty("--rawwidth", "0px" );
         resolve(true);
       });
     });

--- a/src/cardhotbar/card-hotbar.js
+++ b/src/cardhotbar/card-hotbar.js
@@ -1,5 +1,6 @@
 //import { Deck } from "../scripts/deck.js";
 import {DeckForm} from '../scripts/DeckForm.js';
+//import { updateIdentifier } from 'typescript';
 
 export class cardHotbar extends Hotbar {
     /**
@@ -39,6 +40,12 @@ export class cardHotbar extends Hotbar {
     /**
      * 
      */
+    this.totScaledWidth = 0;
+
+
+    /**
+     * 
+     */    
     this.populator = populator;
   }
   
@@ -75,6 +82,7 @@ export class cardHotbar extends Hotbar {
   _getcardMacrosByPage(page) { 
     let lastCard = false;
     const macros = this.getcardHotbarMacros(page);
+    this.totScaledWidth = 0;
     for ( let [i, m] of macros.entries() ) {
       m.key = i<53 ? i+1 : 0;
       m.cssClass = m.macro ? "active" : "inactive";    
@@ -83,9 +91,10 @@ export class cardHotbar extends Hotbar {
       //TO DO: improve to replace hard-coded value with the default draw-mode?
       //getComputedStyle(document.documentElement).getPropertyValue('--width');
       //element.style.setProperty("--my-var", jsVar + 4);
-      let defaultWidth = 138;
+      let defaultWidth = m.icon ? 138 : 0;
       let sw = m.macro ? m.macro.getFlag("world","scaledWidth") || defaultWidth : defaultWidth;
       m.scaledWidth = sw ? sw : defaultWidth;
+      this.totScaledWidth += m.scaledWidth; 
       let defaultSide = "front";
       let curSide = m.macro ? m.macro.getFlag("world","sideUp") || defaultSide : defaultSide;
       m.sideUp = curSide ? curSide : defaultSide;
@@ -109,6 +118,9 @@ export class cardHotbar extends Hotbar {
         lastCard = true;
       }
     }
+    let root = document.documentElement;
+    root.style.setProperty("--rawwidth", ( ui.cardHotbar.totScaledWidth + "px") );
+    console.debug(`Card Hotbar | Total image widths is: ${this.totScaledWidth}`);
     return macros;
   }
 

--- a/src/cardhotbar/css/card-hotbar.css
+++ b/src/cardhotbar/css/card-hotbar.css
@@ -3,7 +3,9 @@
 :root {
     --width: 138px;
     --xoffset: 0px;
-    --totwidth: calc(100vw - 600px - var(--xoffset) );
+    --rawwidth: 100vw; 
+    --totwidth: min( var(--rawwidth), calc(100vw - 600px - var(--xoffset) ) );
+    /* --totwidth: calc( 100vw - 600px - var(--xoffset) ); */
 }
 
 /* TO DO: figure out why so wide, even after hiding cards */

--- a/src/cardhotbar/css/card-hotbar.css
+++ b/src/cardhotbar/css/card-hotbar.css
@@ -20,6 +20,7 @@
 
 #card-hotbar.collapsed {
     height: 50px;
+    width: var(--totwidth);
 }
 
 #card-hotbar #card-hotbar-directory-controls {

--- a/src/cardhotbar/css/card-hotbar.css
+++ b/src/cardhotbar/css/card-hotbar.css
@@ -330,6 +330,15 @@ div#client-settings div#chbSetDiv {
   order: -1;
 }
 
+#client-settings form .form-group.submenu.chb-setting button label {
+    display: inline-block;
+    padding-top: 0px;
+    margin-top: -8px;
+    margin-left: 5px;
+    line-height: 22px;
+    vertical-align: middle;
+}
+
 .macro .tooltip span {
     z-index: 4;
 }

--- a/src/cardhotbar/css/card-hotbar.css
+++ b/src/cardhotbar/css/card-hotbar.css
@@ -2,6 +2,8 @@
 
 :root {
     --width: 138px;
+    --xoffset: 0px;
+    --totwidth: calc(100vw - 600px - var(--xoffset) );
 }
 
 /* TO DO: figure out why so wide, even after hiding cards */
@@ -84,7 +86,7 @@
 #card-hotbar #card-action-bar {
     pointer-events: all;
     height: 100%;
-    width: calc(100vw - 600px);
+    width: var(--totwidth);
 }
 
 #card-hotbar .bar-controls {
@@ -122,13 +124,11 @@
     justify-content: center;
     align-items: center;
     position: relative;
-    /* border: 1px dashed #999999; */
     border-radius: 10px;
     background: #99999980;
     cursor: pointer;
     margin-top: auto;
     margin-bottom: auto;
-    /*width: var(--width);*/
     height: 100%;
     top: 0px;
     box-shadow: 0px 0 4px black;

--- a/src/cardhotbar/css/card-hotbar.css
+++ b/src/cardhotbar/css/card-hotbar.css
@@ -32,6 +32,7 @@
 }
 
 #card-hotbar #card-hotbar-directory-controls.collapsed img.collapsed {
+    border: none;
     display: block;
 }
 
@@ -64,10 +65,21 @@
     margin-bottom: auto;
 }
 
+#card-hotbar #card-hotbar-directory-controls div.vertbar a img {
+    border: none;
+}
+
+
 #card-hotbar #card-hotbar-directory-controls div.expanded a {
     margin-top: auto;
     margin-bottom: auto;
 }
+
+#card-hotbar #card-hotbar-directory-controls div.expanded a {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
 
 #card-hotbar #card-action-bar {
     pointer-events: all;

--- a/src/cardhotbar/index.js
+++ b/src/cardhotbar/index.js
@@ -66,11 +66,11 @@ async function cardHotbarInit() {
   , style = document.createElement('style');
 
   head.appendChild(style);
+  style.type = 'text/css';
+  style.appendChild(document.createTextNode(css));
 
   let root = document.documentElement;
   root.style.setProperty("--xoffset", ( cardHotbarSettings.getCHBXPos() - 220 )+ "px");
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(css));
 
 //  ui.hotbar.render();
 
@@ -117,7 +117,7 @@ Hooks.once("init", async () => {
   };
 });
 
-Hooks.once('ready', () => {
+Hooks.once('ready', async () => {
   //console.debug("Card Hotbar | Foundry setup...");
 
   //Check to make sure that a hotbar rendered before initilizing so that PopOut module windows do not have unwanted card hotbars.
@@ -126,9 +126,9 @@ Hooks.once('ready', () => {
   //console.debug(hotbarTest);
  
   if ( hotbarTest ) {
-    cardHotbarInit();
+    await cardHotbarInit();
   }
-
+  
 });
 
 Hooks.on("renderSettingsConfig", async () => {

--- a/src/cardhotbar/index.js
+++ b/src/cardhotbar/index.js
@@ -67,6 +67,8 @@ async function cardHotbarInit() {
 
   head.appendChild(style);
 
+  let root = document.documentElement;
+  root.style.setProperty("--xoffset", ( cardHotbarSettings.getCHBXPos() - 220 )+ "px");
   style.type = 'text/css';
   style.appendChild(document.createTextNode(css));
 

--- a/src/cardhotbar/scripts/card-hotbar-populator.js
+++ b/src/cardhotbar/scripts/card-hotbar-populator.js
@@ -2,8 +2,7 @@
 
 export class cardHotbarPopulator {
     constructor() { 
-        this.macroMap = this.chbGetMacros();
-        getComputedStyle(document.documentElement).getPropertyValue('--width');    
+        this.macroMap = this.chbGetMacros();    
         console.debug("Card Hotbar | Initial state:");
         console.debug(this.macroMap);
     }

--- a/src/cardhotbar/scripts/card-hotbar-settings.js
+++ b/src/cardhotbar/scripts/card-hotbar-settings.js
@@ -11,7 +11,7 @@ export class cardHotbarSettings {
         game.settings.registerMenu("cardsupport", 'chbSettingsMenu', {
             name: '(𝗚𝗠 𝗢𝗻𝗹𝘆) Default Player Hand Settings for All Users',
             label: 'Global Player Hand',
-            icon: 'fas fa-bars',
+            icon: 'icon-pokerhand fa-2x',
             type: cardHotbarSettingsForm,
             restricted: true
         });
@@ -20,7 +20,7 @@ export class cardHotbarSettings {
         game.settings.registerMenu("cardsupport", 'chbFlagsMenu', {
             name: 'Your Hand of Cards Settings',
             label: 'Your Hand of Cards',
-            icon: 'fas fa-bars',
+            icon: 'icon-pokerhand fa-2x',
             type: cardHotbarFlagsForm,
             restricted: false
         });

--- a/src/cardhotbar/templates/cardHotbar.html
+++ b/src/cardhotbar/templates/cardHotbar.html
@@ -6,7 +6,7 @@
             <img src="modules/cardsupport/cardhotbar/img/poker-hand.png" class="collapsed">
         </a>
         <div class= "expanded vertbar" >        
-            <a id="chbDiscardAll" title="Discard All"><i class="fas fa-trash" ></i></a>
+            <a id="chbDiscardAll" title="Discard All"><i class="fas fa-inbox" ></i></a>
             <a id="chbTakeFromPlayer" title="Take From Player"><i class="icon-hand" ></i></a>
             <a id="chbInteractDecks" title="Interact with Decks"><i class="icon-deck-of-cards"></i></a>
         </div>

--- a/src/cardhotbar/templates/cardHotbar.html
+++ b/src/cardhotbar/templates/cardHotbar.html
@@ -2,8 +2,8 @@
     <div id="card-hotbar-directory-controls" class="bar-controls flexcol">
         <a id="card-bar-toggle">
             <i class="fas fa-times"></i>
-            <i class="fas fa-caret-down"></i>
-            <i class="collapsed icon-pokerhand"></i>
+            <i class="fas fa-caret-up"></i>
+            <img src="modules/cardsupport/cardhotbar/img/poker-hand.png" class="collapsed">
         </a>
         <div class= "expanded vertbar" >        
             <a id="chbDiscardAll" title="Discard All"><i class="fas fa-trash" ></i></a>

--- a/src/module.json
+++ b/src/module.json
@@ -3,7 +3,7 @@
   "title": "Card Support (Unofficial)",
   "description": "Unofficial deck support for foundry that allows you to have cards and player hands and the like.",
   "author": "Spacemandev, Norc",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.7.0",
   "url": "https://github.com/Brownie79/fvtt-card-support",


### PR DESCRIPTION
Fixed the last known issues with the CSS for the Card Hotbar:

1) no longer blocks space unnecessarily (if there's no card present)
2) Doesn't take up any extra space while collapsed
3) Gracefully handles changing the X position of the Card Hotbar using the settings.

Cosmetic fixes:

1) The 'vertbar" of the Card Hotbar (better expand/collapse behavior, changed the Discard Hand icon to Inbox for consistency)
2)  Used the Pokerhand icons in the Settings button now instead of the bar icons.